### PR TITLE
Refactor and extend IdentityX service registration

### DIFF
--- a/Application/Extensions/ServiceExtensions.cs
+++ b/Application/Extensions/ServiceExtensions.cs
@@ -10,7 +10,7 @@ namespace IdentityX.Application.Extensions
 {
 	public static class ServiceExtensions
 	{
-		public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+		public static IServiceCollection AddIdentityXAuthentication(this IServiceCollection services, IConfiguration configuration)
 		{
 			services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 				.AddJwtBearer(options =>
@@ -28,14 +28,29 @@ namespace IdentityX.Application.Extensions
 				});
 
 			services.AddScoped<ITokenService, TokenService>();
+
+			return services;
+		}
+
+		public static IServiceCollection AddIdentityXUserManagement<EmailServiceImplementation, DataServiceImplementation>(this IServiceCollection services)
+		{
+			services.AddScoped(typeof(IEmailService), typeof(EmailServiceImplementation));
+			services.AddScoped(typeof(IDataService), typeof(DataServiceImplementation));
+
 			services.AddScoped<IAccountService, AccountService>();
 			services.AddScoped<IProfileService, ProfileService>();
+
+			return services;
+		}
+
+		public static IServiceCollection AddIdentityXMultiFactorAuthentication(this IServiceCollection services)
+		{
 			services.AddScoped<IMultiFactorAuthService, MultiFactorAuthService>();
 
 			return services;
 		}
 
-		public static IServiceCollection AddRoleBasedAuthorization(this IServiceCollection services)
+		public static IServiceCollection AddIdentityXRoleBasedAuthorization(this IServiceCollection services)
 		{
 			services.AddAuthorization(options =>
 			{


### PR DESCRIPTION
Renamed methods to follow the IdentityX naming convention:
- `AddJwtAuthentication` to `AddIdentityXAuthentication`
- `AddRoleBasedAuthorization` to `AddIdentityXRoleBasedAuthorization`

Added new methods for enhanced functionality:
- `AddIdentityXUserManagement` for registering user management services
- `AddIdentityXMultiFactorAuthentication` for registering multi-factor authentication service

These changes improve modularity and clarity in the `IdentityX.Application.Extensions` namespace.